### PR TITLE
Add TAG to IPV4 interface IP address

### DIFF
--- a/docs/data-sources/ipv4_interface_address.md
+++ b/docs/data-sources/ipv4_interface_address.md
@@ -39,4 +39,5 @@ data "nxos_ipv4_interface_address" "example" {
 ### Read-Only
 
 - `id` (String) The distinguished name of the object.
+- `tag` (Number) Route Tag
 - `type` (String) Address type.

--- a/docs/resources/ipv4_interface_address.md
+++ b/docs/resources/ipv4_interface_address.md
@@ -27,6 +27,7 @@ resource "nxos_ipv4_interface_address" "example" {
   interface_id = "eth1/10"
   address      = "24.63.46.49/30"
   type         = "primary"
+  tag          = 1234
 }
 ```
 
@@ -42,6 +43,8 @@ resource "nxos_ipv4_interface_address" "example" {
 ### Optional
 
 - `device` (String) A device name from the provider configuration.
+- `tag` (Number) Route Tag
+  - Default value: `0`
 - `type` (String) Address type.
   - Choices: `primary`, `secondary`
   - Default value: `primary`

--- a/examples/resources/nxos_ipv4_interface_address/resource.tf
+++ b/examples/resources/nxos_ipv4_interface_address/resource.tf
@@ -3,4 +3,5 @@ resource "nxos_ipv4_interface_address" "example" {
   interface_id = "eth1/10"
   address      = "24.63.46.49/30"
   type         = "primary"
+  tag          = 1234
 }

--- a/gen/definitions/ipv4_interface_address.yaml
+++ b/gen/definitions/ipv4_interface_address.yaml
@@ -38,6 +38,12 @@ attributes:
       - secondary
     default_value: 'primary'
     example: 'primary'
+  - nxos_name: tag
+    tf_name: tag
+    type: Int64
+    description: 'Route Tag'
+    default_value: 0
+    example: 1234
 test_prerequisites:
   - dn: sys/intf/phys-[eth1/10]
     class_name: l1PhysIf

--- a/internal/provider/data_source_nxos_ipv4_interface_address.go
+++ b/internal/provider/data_source_nxos_ipv4_interface_address.go
@@ -79,6 +79,10 @@ func (d *IPv4InterfaceAddressDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "Address type.",
 				Computed:            true,
 			},
+			"tag": schema.Int64Attribute{
+				MarkdownDescription: "Route Tag",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_nxos_ipv4_interface_address_test.go
+++ b/internal/provider/data_source_nxos_ipv4_interface_address_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceNxosIPv4InterfaceAddress(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nxos_ipv4_interface_address.test", "address", "24.63.46.49/30"),
 					resource.TestCheckResourceAttr("data.nxos_ipv4_interface_address.test", "type", "primary"),
+					resource.TestCheckResourceAttr("data.nxos_ipv4_interface_address.test", "tag", "1234"),
 				),
 			},
 		},
@@ -74,6 +75,7 @@ resource "nxos_ipv4_interface_address" "test" {
   interface_id = "eth1/10"
   address = "24.63.46.49/30"
   type = "primary"
+  tag = 1234
   depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, ]
 }
 

--- a/internal/provider/model_nxos_ipv4_interface_address.go
+++ b/internal/provider/model_nxos_ipv4_interface_address.go
@@ -21,6 +21,7 @@ package provider
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/netascode/go-nxos"
@@ -35,6 +36,7 @@ type IPv4InterfaceAddress struct {
 	InterfaceId types.String `tfsdk:"interface_id"`
 	Address     types.String `tfsdk:"address"`
 	Type        types.String `tfsdk:"type"`
+	Tag         types.Int64  `tfsdk:"tag"`
 }
 
 func (data IPv4InterfaceAddress) getDn() string {
@@ -57,6 +59,9 @@ func (data IPv4InterfaceAddress) toBody(statusReplace bool) nxos.Body {
 	if (!data.Type.IsUnknown() && !data.Type.IsNull()) || true {
 		body, _ = sjson.Set(body, data.getClassName()+".attributes."+"type", data.Type.ValueString())
 	}
+	if (!data.Tag.IsUnknown() && !data.Tag.IsNull()) || true {
+		body, _ = sjson.Set(body, data.getClassName()+".attributes."+"tag", strconv.FormatInt(data.Tag.ValueInt64(), 10))
+	}
 
 	return nxos.Body{body}
 }
@@ -71,6 +76,11 @@ func (data *IPv4InterfaceAddress) fromBody(res gjson.Result, all bool) {
 		data.Type = types.StringValue(res.Get(data.getClassName() + ".attributes.type").String())
 	} else {
 		data.Type = types.StringNull()
+	}
+	if !data.Tag.IsNull() || all {
+		data.Tag = types.Int64Value(res.Get(data.getClassName() + ".attributes.tag").Int())
+	} else {
+		data.Tag = types.Int64Null()
 	}
 }
 

--- a/internal/provider/resource_nxos_ipv4_interface_address.go
+++ b/internal/provider/resource_nxos_ipv4_interface_address.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -99,6 +100,12 @@ func (r *IPv4InterfaceAddressResource) Schema(ctx context.Context, req resource.
 				Validators: []validator.String{
 					stringvalidator.OneOf("primary", "secondary"),
 				},
+			},
+			"tag": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Route Tag").AddDefaultValueDescription("0").String,
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(0),
 			},
 		},
 	}

--- a/internal/provider/resource_nxos_ipv4_interface_address_test.go
+++ b/internal/provider/resource_nxos_ipv4_interface_address_test.go
@@ -37,6 +37,7 @@ func TestAccNxosIPv4InterfaceAddress(t *testing.T) {
 					resource.TestCheckResourceAttr("nxos_ipv4_interface_address.test", "interface_id", "eth1/10"),
 					resource.TestCheckResourceAttr("nxos_ipv4_interface_address.test", "address", "24.63.46.49/30"),
 					resource.TestCheckResourceAttr("nxos_ipv4_interface_address.test", "type", "primary"),
+					resource.TestCheckResourceAttr("nxos_ipv4_interface_address.test", "tag", "1234"),
 				),
 			},
 			{
@@ -92,6 +93,7 @@ func testAccNxosIPv4InterfaceAddressConfig_all() string {
 		interface_id = "eth1/10"
 		address = "24.63.46.49/30"
 		type = "primary"
+		tag = 1234
   		depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, ]
 	}
 	`


### PR DESCRIPTION
IPv4 address is missing TAG on the ip address. 