### PR TITLE
Add evpn attribute to nxos_bgp_advertised_prefix resource and data source

### DIFF
--- a/docs/data-sources/bgp_advertised_prefix.md
+++ b/docs/data-sources/bgp_advertised_prefix.md
@@ -40,5 +40,6 @@ data "nxos_bgp_advertised_prefix" "example" {
 
 ### Read-Only
 
+- `evpn` (String) Evpn to advertise route towards evpn side
 - `id` (String) The distinguished name of the object.
 - `route_map` (String) Route map to modify attributes.

--- a/docs/resources/bgp_advertised_prefix.md
+++ b/docs/resources/bgp_advertised_prefix.md
@@ -28,6 +28,7 @@ resource "nxos_bgp_advertised_prefix" "example" {
   address_family = "ipv4-ucast"
   prefix         = "192.168.1.0/24"
   route_map      = "rt-map"
+  evpn           = "enabled"
 }
 ```
 
@@ -46,6 +47,8 @@ resource "nxos_bgp_advertised_prefix" "example" {
 ### Optional
 
 - `device` (String) A device name from the provider configuration.
+- `evpn` (String) Evpn to advertise route towards evpn side
+  - Choices: `enabled`, `disabled`
 - `route_map` (String) Route map to modify attributes.
 
 ### Read-Only

--- a/docs/resources/bgp_advertised_prefix.md
+++ b/docs/resources/bgp_advertised_prefix.md
@@ -49,6 +49,7 @@ resource "nxos_bgp_advertised_prefix" "example" {
 - `device` (String) A device name from the provider configuration.
 - `evpn` (String) Evpn to advertise route towards evpn side
   - Choices: `enabled`, `disabled`
+  - Default value: `disabled`
 - `route_map` (String) Route map to modify attributes.
 
 ### Read-Only

--- a/examples/resources/nxos_bgp_advertised_prefix/resource.tf
+++ b/examples/resources/nxos_bgp_advertised_prefix/resource.tf
@@ -4,4 +4,5 @@ resource "nxos_bgp_advertised_prefix" "example" {
   address_family = "ipv4-ucast"
   prefix         = "192.168.1.0/24"
   route_map      = "rt-map"
+  evpn           = "enabled"
 }

--- a/gen/definitions/bgp_advertised_prefix.yaml
+++ b/gen/definitions/bgp_advertised_prefix.yaml
@@ -66,7 +66,7 @@ attributes:
       - enabled
       - disabled
     example: enabled
-    delete_value: disabled
+    default_value: disabled
 test_prerequisites:
   - dn: sys/fm/bgp
     class_name: fmBgp

--- a/gen/definitions/bgp_advertised_prefix.yaml
+++ b/gen/definitions/bgp_advertised_prefix.yaml
@@ -58,6 +58,15 @@ attributes:
     description: "Route map to modify attributes."
     default_value: ""
     example: rt-map
+  - nxos_name: evpn
+    tf_name: evpn
+    type: String
+    description: 'Evpn to advertise route towards evpn side'
+    enum_values:
+      - enabled
+      - disabled
+    example: enabled
+    delete_value: disabled
 test_prerequisites:
   - dn: sys/fm/bgp
     class_name: fmBgp

--- a/internal/provider/data_source_nxos_bgp_advertised_prefix.go
+++ b/internal/provider/data_source_nxos_bgp_advertised_prefix.go
@@ -83,6 +83,10 @@ func (d *BGPAdvertisedPrefixDataSource) Schema(ctx context.Context, req datasour
 				MarkdownDescription: "Route map to modify attributes.",
 				Computed:            true,
 			},
+			"evpn": schema.StringAttribute{
+				MarkdownDescription: "Evpn to advertise route towards evpn side",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_nxos_bgp_advertised_prefix_test.go
+++ b/internal/provider/data_source_nxos_bgp_advertised_prefix_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceNxosBGPAdvertisedPrefix(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nxos_bgp_advertised_prefix.test", "prefix", "192.168.1.0/24"),
 					resource.TestCheckResourceAttr("data.nxos_bgp_advertised_prefix.test", "route_map", "rt-map"),
+					resource.TestCheckResourceAttr("data.nxos_bgp_advertised_prefix.test", "evpn", "enabled"),
 				),
 			},
 		},
@@ -95,6 +96,7 @@ resource "nxos_bgp_advertised_prefix" "test" {
   address_family = "ipv4-ucast"
   prefix = "192.168.1.0/24"
   route_map = "rt-map"
+  evpn = "enabled"
   depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]
 }
 

--- a/internal/provider/model_nxos_bgp_advertised_prefix.go
+++ b/internal/provider/model_nxos_bgp_advertised_prefix.go
@@ -88,7 +88,6 @@ func (data *BGPAdvertisedPrefix) fromBody(res gjson.Result, all bool) {
 
 func (data BGPAdvertisedPrefix) toDeleteBody() nxos.Body {
 	body := ""
-	body, _ = sjson.Set(body, data.getClassName()+".attributes."+"evpn", "disabled")
 
 	return nxos.Body{body}
 }

--- a/internal/provider/model_nxos_bgp_advertised_prefix.go
+++ b/internal/provider/model_nxos_bgp_advertised_prefix.go
@@ -38,6 +38,7 @@ type BGPAdvertisedPrefix struct {
 	AddressFamily types.String `tfsdk:"address_family"`
 	Prefix        types.String `tfsdk:"prefix"`
 	RouteMap      types.String `tfsdk:"route_map"`
+	Evpn          types.String `tfsdk:"evpn"`
 }
 
 func (data BGPAdvertisedPrefix) getDn() string {
@@ -60,6 +61,9 @@ func (data BGPAdvertisedPrefix) toBody(statusReplace bool) nxos.Body {
 	if (!data.RouteMap.IsUnknown() && !data.RouteMap.IsNull()) || true {
 		body, _ = sjson.Set(body, data.getClassName()+".attributes."+"rtMap", data.RouteMap.ValueString())
 	}
+	if (!data.Evpn.IsUnknown() && !data.Evpn.IsNull()) || true {
+		body, _ = sjson.Set(body, data.getClassName()+".attributes."+"evpn", data.Evpn.ValueString())
+	}
 
 	return nxos.Body{body}
 }
@@ -75,10 +79,16 @@ func (data *BGPAdvertisedPrefix) fromBody(res gjson.Result, all bool) {
 	} else {
 		data.RouteMap = types.StringNull()
 	}
+	if !data.Evpn.IsNull() || all {
+		data.Evpn = types.StringValue(res.Get(data.getClassName() + ".attributes.evpn").String())
+	} else {
+		data.Evpn = types.StringNull()
+	}
 }
 
 func (data BGPAdvertisedPrefix) toDeleteBody() nxos.Body {
 	body := ""
+	body, _ = sjson.Set(body, data.getClassName()+".attributes."+"evpn", "disabled")
 
 	return nxos.Body{body}
 }

--- a/internal/provider/resource_nxos_bgp_advertised_prefix.go
+++ b/internal/provider/resource_nxos_bgp_advertised_prefix.go
@@ -104,6 +104,13 @@ func (r *BGPAdvertisedPrefixResource) Schema(ctx context.Context, req resource.S
 				MarkdownDescription: helpers.NewAttributeDescription("Route map to modify attributes.").String,
 				Optional:            true,
 			},
+			"evpn": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Evpn to advertise route towards evpn side").AddStringEnumDescription("enabled", "disabled").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("enabled", "disabled"),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_nxos_bgp_advertised_prefix.go
+++ b/internal/provider/resource_nxos_bgp_advertised_prefix.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -105,8 +106,10 @@ func (r *BGPAdvertisedPrefixResource) Schema(ctx context.Context, req resource.S
 				Optional:            true,
 			},
 			"evpn": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Evpn to advertise route towards evpn side").AddStringEnumDescription("enabled", "disabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Evpn to advertise route towards evpn side").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("disabled").String,
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("disabled"),
 				Validators: []validator.String{
 					stringvalidator.OneOf("enabled", "disabled"),
 				},

--- a/internal/provider/resource_nxos_bgp_advertised_prefix_test.go
+++ b/internal/provider/resource_nxos_bgp_advertised_prefix_test.go
@@ -38,6 +38,7 @@ func TestAccNxosBGPAdvertisedPrefix(t *testing.T) {
 					resource.TestCheckResourceAttr("nxos_bgp_advertised_prefix.test", "address_family", "ipv4-ucast"),
 					resource.TestCheckResourceAttr("nxos_bgp_advertised_prefix.test", "prefix", "192.168.1.0/24"),
 					resource.TestCheckResourceAttr("nxos_bgp_advertised_prefix.test", "route_map", "rt-map"),
+					resource.TestCheckResourceAttr("nxos_bgp_advertised_prefix.test", "evpn", "enabled"),
 				),
 			},
 			{
@@ -115,6 +116,7 @@ func testAccNxosBGPAdvertisedPrefixConfig_all() string {
 		address_family = "ipv4-ucast"
 		prefix = "192.168.1.0/24"
 		route_map = "rt-map"
+		evpn = "enabled"
   		depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]
 	}
 	`


### PR DESCRIPTION
```
=== RUN   TestAccNxosBGPAdvertisedPrefix
--- PASS: TestAccNxosBGPAdvertisedPrefix (1.47s)
```

Evpn was a missing optional property of nxos_bgp_advertised_prefix (bgp:AdvPrefix)